### PR TITLE
Handle creation and update outcomes in ResourceStore

### DIFF
--- a/src/FhirStore.CommonVersioned/Storage/ResourceStore.cs
+++ b/src/FhirStore.CommonVersioned/Storage/ResourceStore.cs
@@ -936,9 +936,14 @@ public class ResourceStore<T> : IVersionedResourceStore
                 _ = _store.Terminology.StoreProcessValueSet(vs);
                 break;
         }
-
-        outcome = SerializationUtils.BuildOutcomeForRequest(HttpStatusCode.OK, $"Updated {_resourceName}/{source.Id} to version {source.Meta.VersionId}");
-        sc = HttpStatusCode.OK;
+        
+        if (previous == null){
+          sc = HttpStatusCode.Created;
+          outcome = SerializationUtils.BuildOutcomeForRequest(HttpStatusCode.OK, $"Created {_resourceName}/{source.Id} to version {source.Meta.VersionId}");
+        }else{
+          sc = HttpStatusCode.OK;
+          outcome = SerializationUtils.BuildOutcomeForRequest(HttpStatusCode.OK, $"Updated {_resourceName}/{source.Id} to version {source.Meta.VersionId}");
+        }                
         return source;
     }
 

--- a/src/fhir-candle.Tests/FhirStoreTestsR5.cs
+++ b/src/fhir-candle.Tests/FhirStoreTestsR5.cs
@@ -753,7 +753,6 @@ public class FhirStoreTestsR5: IDisposable
             out FhirResponseContext response);
 
         success.ShouldBeTrue();
-        response.StatusCode.ShouldBe(HttpStatusCode.OK);
         response.Location.ShouldContain(resourceType);
 
         serializedResource = response.SerializedResource;

--- a/src/fhir-candle.Tests/FhirStoreTestsR5.cs
+++ b/src/fhir-candle.Tests/FhirStoreTestsR5.cs
@@ -502,7 +502,7 @@ public class FhirStoreTestsR5: IDisposable
 
         encounterJson = encounterJson.Replace("in-progress", "completed");
 
-        DoUpdate(
+        var firstUpdateResponse = DoUpdate(
             "Encounter",
             "virtual-in-progress",
             encounterJson,
@@ -512,6 +512,8 @@ public class FhirStoreTestsR5: IDisposable
             out eTag,
             out lastModified,
             out location);
+
+        firstUpdateResponse.ShouldBe(HttpStatusCode.Created, "This update request should have been treated as Create since we are creating the first version.");
 
         notification = fhirStore.SerializeSubscriptionEvents(
             "encounter-complete-fhirpath",
@@ -529,6 +531,19 @@ public class FhirStoreTestsR5: IDisposable
         resource.ShouldNotBeNull();
         resource.EventsSinceSubscriptionStart.ShouldNotBeNull();
         resource.EventsSinceSubscriptionStart.ToString().ShouldBeEquivalentTo("1");
+
+        var secondUpdateResponse = DoUpdate(
+            "Encounter",
+            "virtual-in-progress",
+            encounterJson,
+            fhirStore,
+            out serializedResource,
+            out serializedOutcome,
+            out eTag,
+            out lastModified,
+            out location);
+        
+        secondUpdateResponse.ShouldBe(HttpStatusCode.OK, "This update request should have been treated as Update since we are updating the second version.");
 
         //_testOutputHelper.WriteLine(bundle);
     }
@@ -604,7 +619,7 @@ public class FhirStoreTestsR5: IDisposable
 
         encounterJson = encounterJson.Replace("in-progress", "completed");
 
-        DoUpdate(
+        var firstUpdateResponse = DoUpdate(
             "Encounter",
             "virtual-in-progress",
             encounterJson,
@@ -614,6 +629,8 @@ public class FhirStoreTestsR5: IDisposable
             out eTag,
             out lastModified,
             out location);
+
+        firstUpdateResponse.ShouldBe(HttpStatusCode.Created, "This update request should have been treated as Create since we are creating the first version.");
 
         notification = fhirStore.SerializeSubscriptionEvents(
             "encounter-complete-query",
@@ -631,6 +648,19 @@ public class FhirStoreTestsR5: IDisposable
         resource.ShouldNotBeNull();
         resource.EventsSinceSubscriptionStart.ShouldNotBeNull();
         resource.EventsSinceSubscriptionStart.ToString().ShouldBeEquivalentTo("1");
+
+        var secondUpdateResponse = DoUpdate(
+            "Encounter",
+            "virtual-in-progress",
+            encounterJson,
+            fhirStore,
+            out serializedResource,
+            out serializedOutcome,
+            out eTag,
+            out lastModified,
+            out location);
+
+        secondUpdateResponse.ShouldBe(HttpStatusCode.OK, "This update request should have been treated as Update since we are updating the second version.");
 
         //_testOutputHelper.WriteLine(bundle);
     }

--- a/src/fhir-candle.Tests/R4Tests.cs
+++ b/src/fhir-candle.Tests/R4Tests.cs
@@ -1310,7 +1310,7 @@ public class R4TestConditionalUpdates : IClassFixture<R4Tests>
             out FhirResponseContext response);
 
         success.ShouldBeTrue();
-        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
         response.SerializedResource.ShouldNotBeNullOrEmpty();
         response.SerializedOutcome.ShouldNotBeNullOrEmpty();
         response.ETag.ShouldBe("W/\"1\"");


### PR DESCRIPTION
When a client attempts to update a resource that doesn't exist in our storage, the system creates a new version based on the configuration. However, the HTTP response status should be 201 (Created) instead of 200 (OK) in this case.

This change will help clients distinguish between create and update operations  for HTTP PUT requests.

closes #49