### PR TITLE
Omit empty location/etag from Bundle.entry.response

### DIFF
--- a/src/FhirStore.CommonVersioned/Storage/VersionedFhirStore.cs
+++ b/src/FhirStore.CommonVersioned/Storage/VersionedFhirStore.cs
@@ -7050,9 +7050,9 @@ rs,
                     {
                         Status = getResponseStatus(opResponse.StatusCode ?? HttpStatusCode.OK),
                         Outcome = (Resource?)opResponse.Outcome,
-                        Etag = opResponse.ETag ?? string.Empty,
+                        Etag = string.IsNullOrEmpty(opResponse.ETag) ? null : opResponse.ETag,
                         LastModified = ((Resource?)opResponse.Resource)?.Meta?.LastUpdated ?? null,
-                        Location = opResponse.Location ?? string.Empty,
+                        Location = string.IsNullOrEmpty(opResponse.Location) ? null : opResponse.Location,
                     },
                 });
             }
@@ -7189,9 +7189,9 @@ rs,
                     {
                         Status = getResponseStatus(opResponse.StatusCode ?? HttpStatusCode.OK),
                         Outcome = (Resource?)opResponse.Outcome,
-                        Etag = opResponse.ETag ?? string.Empty,
+                        Etag = string.IsNullOrEmpty(opResponse.ETag) ? null : opResponse.ETag,
                         LastModified = ((Resource?)opResponse.Resource)?.Meta?.LastUpdated ?? null,
-                        Location = opResponse.Location ?? string.Empty,
+                        Location = string.IsNullOrEmpty(opResponse.Location) ? null : opResponse.Location,
                     },
                 });
             }


### PR DESCRIPTION
Closes #51.

In `VersionedFhirStore.ProcessTransaction` and `ProcessBatch`, `opResponse.ETag` and `opResponse.Location` are coerced to `string.Empty` when absent, which serializes as `"location": ""` / `"etag": ""` in the response Bundle and violates FHIR R4's rule that primitives must not be empty strings.

Strict R4 parsers — including the Firely .NET SDK — reject these responses with `StructuralTypeException: The property 'location' has an empty string value, which is not allowed.`, making fhir-candle unusable as a test double for any Firely-based pipeline that exercises transactions or batches with searches.

This patch sets the elements to `null` so they're omitted from serialization when there is no value to report.

## Verification

After the patch, the repro from the issue returns:

```json
"response": {
    "status": "200 OK",
    "outcome": { ... }
}
```

