### PR TITLE
POST with existing id: return 409 Conflict instead of 500

### DIFF
--- a/src/FhirStore.CommonVersioned/Storage/VersionedFhirStore.cs
+++ b/src/FhirStore.CommonVersioned/Storage/VersionedFhirStore.cs
@@ -1535,8 +1535,28 @@ public partial class VersionedFhirStore : IFhirStore
             }
         }
 
+        // When AllowExistingId is on, the resource store preserves the client-supplied
+        // id. If that id already exists, surface that explicitly as 409 Conflict rather
+        // than the generic 500 the catch-all "stored is null" branch would otherwise
+        // produce.
+        bool useExistingId = forceExistingId || _config.AllowExistingId;
+        if (useExistingId
+            && !string.IsNullOrEmpty(content.Id)
+            && ((IReadOnlyDictionary<string, Resource>)rs).ContainsKey(content.Id))
+        {
+            response = new()
+            {
+                Outcome = SerializationUtils.BuildOutcomeForRequest(
+                    HttpStatusCode.Conflict,
+                    $"Resource {resourceType}/{content.Id} already exists",
+                    OperationOutcome.IssueType.Duplicate),
+                StatusCode = HttpStatusCode.Conflict,
+            };
+            return false;
+        }
+
         // create the resource
-        Resource? stored = rs.InstanceCreate(ctx, content, forceExistingId || _config.AllowExistingId);
+        Resource? stored = rs.InstanceCreate(ctx, content, useExistingId);
         Resource? sForHook = null;
 
         foreach (IFhirInteractionHook hook in hooks)

--- a/src/fhir-candle.Tests/FromIssues.cs
+++ b/src/fhir-candle.Tests/FromIssues.cs
@@ -93,4 +93,55 @@ public class FromIssueTestsR4
         entry.Response.ShouldNotBeNull();
         entry.Response.Status.ShouldBe("201 Created");
     }
+
+    /// <summary>
+    /// Tests that a POST creating a resource whose client-supplied id collides
+    /// with an existing one returns 409 Conflict, not 500 Internal Server Error.
+    ///
+    /// When `AllowExistingId=true`, candle preserves the client-supplied id on
+    /// POST. A subsequent POST with the same id collides and currently returns
+    /// 500 with a generic "Failed to create resource" diagnostic. Per FHIR R4
+    /// and HTTP semantics, a state conflict on create should surface as 409.
+    /// </summary>
+    [Fact]
+    public void PostWithExistingIdShouldReturn409NotServerError()
+    {
+        TenantConfiguration config = new()
+        {
+            FhirVersion = FhirReleases.FhirSequenceCodes.R4,
+            ControllerName = "r4",
+            BaseUrl = "http://localhost/fhir/r4",
+            LoadDirectory = null,
+            AllowExistingId = true,
+            AllowCreateAsUpdate = true,
+        };
+
+        IFhirStore store = new VersionedFhirStore();
+        store.Init(config);
+
+        const string body = """{"resourceType":"Questionnaire","id":"dup-id","status":"active"}""";
+
+        FhirRequestContext FirstCtx() => new()
+        {
+            TenantName = store.Config.ControllerName,
+            Store = store,
+            HttpMethod = "POST",
+            Url = store.Config.BaseUrl + "/Questionnaire",
+            Forwarded = null,
+            Authorization = null,
+            SourceContent = body,
+            SourceFormat = "application/fhir+json",
+            DestinationFormat = "application/fhir+json",
+            ResourceType = "Questionnaire",
+        };
+
+        store.InstanceCreate(FirstCtx(), out FhirResponseContext firstResponse).ShouldBeTrue();
+        firstResponse.StatusCode.ShouldBe(HttpStatusCode.Created);
+
+        // Second POST with the same client-supplied id.
+        store.InstanceCreate(FirstCtx(), out FhirResponseContext secondResponse);
+        secondResponse.StatusCode.ShouldBe(
+            HttpStatusCode.Conflict,
+            "POST that collides on a client-supplied id should return 409 Conflict, not 500");
+    }
 }


### PR DESCRIPTION
Closes #55.

When `AllowExistingId=true` (the default), `VersionedFhirStore.DoInstanceCreate` calls into the resource store, which silently returns `null` if the client-supplied id already exists. The caller then takes the catch-all "stored is null" branch and emits `500 Internal Server Error` with a generic `"Failed to create resource"` diagnostic.

This patch checks for the collision explicitly and emits `409 Conflict` with `IssueType.Duplicate`, before calling into the resource store. PUT/transaction paths are unaffected (they pass `forceExistingId=true` and follow the upsert semantics).

## Verification

- The failing regression test from this branch (`PostWithExistingIdShouldReturn409NotServerError`) now passes on net8.0/net9.0/net10.0.
- The full candle test suite passes on net8.0/net9.0/net10.0 (693/693).

## Note on the wider design question raised in #55

This patch is the minimal status-code fix. The broader observation — that `AllowExistingId=true` makes `POST` behave as an upsert and silently breaks consumers relying on the FHIR R4 "server SHALL ignore client-supplied id on create" contract — is intentionally left out of this PR so it can be discussed separately. Happy to follow up if you'd like the default flipped.