### PR TITLE
AND-combine repeated query parameters in search

### DIFF
--- a/src/FhirStore.CommonVersioned/Models/ParsedSearchParameter.cs
+++ b/src/FhirStore.CommonVersioned/Models/ParsedSearchParameter.cs
@@ -1094,15 +1094,37 @@ public class ParsedSearchParameter : ICloneable
                 continue;
             }
 
-            results.Add(new ParsedSearchParameter(
-                store,
-                resourceStore,
-                parseResult,
-                query[key] ?? string.Empty,
-                key,
-                query[key]));
+            // Per FHIR R4 §3.1.1.5.7, repeated occurrences of the same parameter
+            // are AND-combined while comma-separated values within a single
+            // occurrence are OR-combined. NameValueCollection.GetValues returns the
+            // distinct occurrences (as separate strings), so emit one
+            // ParsedSearchParameter per occurrence; downstream evaluation already
+            // AND-combines parameter instances of the same name. Falling back to
+            // `query[key]` (which is the comma-joined concatenation) would conflate
+            // the two semantics.
+            string[]? values = query.GetValues(key);
+            if (values is null || values.Length == 0)
+            {
+                results.Add(new ParsedSearchParameter(
+                    store,
+                    resourceStore,
+                    parseResult,
+                    string.Empty,
+                    key,
+                    null));
+                continue;
+            }
 
-            continue;
+            foreach (string value in values)
+            {
+                results.Add(new ParsedSearchParameter(
+                    store,
+                    resourceStore,
+                    parseResult,
+                    value ?? string.Empty,
+                    key,
+                    value));
+            }
         }
 
         return results.ToArray();

--- a/src/fhir-candle.Tests/FromIssues.cs
+++ b/src/fhir-candle.Tests/FromIssues.cs
@@ -93,4 +93,81 @@ public class FromIssueTestsR4
         entry.Response.ShouldNotBeNull();
         entry.Response.Status.ShouldBe("201 Created");
     }
+
+    /// <summary>
+    /// Tests that repeated occurrences of the same search parameter in the query
+    /// string are combined with AND semantics (per FHIR R4 §3.1.1.5.7) rather than
+    /// being collapsed into a comma-separated OR list.
+    ///
+    /// Reproduction: create two Organizations and search with both
+    /// `?name:contains=Foo&amp;name:contains=ZZZNoMatchExpected`. No Organization
+    /// has a name containing both substrings, so the result should be empty.
+    /// Currently candle returns the Foo-matching Organization, indicating the
+    /// repeated parameter is being treated as OR.
+    /// </summary>
+    [Fact]
+    public void RepeatedSearchParameterShouldUseAndSemantics()
+    {
+        TenantConfiguration config = new()
+        {
+            FhirVersion = FhirReleases.FhirSequenceCodes.R4,
+            ControllerName = "r4",
+            BaseUrl = "http://localhost/fhir/r4",
+            LoadDirectory = null,
+            AllowExistingId = true,
+            AllowCreateAsUpdate = true,
+        };
+
+        IFhirStore store = new VersionedFhirStore();
+        store.Init(config);
+
+        // Seed two Organizations with disjoint name tokens.
+        foreach (string orgJson in new[]
+        {
+            """{"resourceType":"Organization","id":"org-foo-bar","name":"Foo Bar Hospital"}""",
+            """{"resourceType":"Organization","id":"org-baz","name":"Baz Hospital"}""",
+        })
+        {
+            FhirRequestContext seedCtx = new()
+            {
+                TenantName = store.Config.ControllerName,
+                Store = store,
+                HttpMethod = "PUT",
+                Url = store.Config.BaseUrl + "/Organization",
+                Forwarded = null,
+                Authorization = null,
+                SourceContent = orgJson,
+                SourceFormat = "application/fhir+json",
+                DestinationFormat = "application/fhir+json",
+                ResourceType = "Organization",
+            };
+            store.InstanceUpdate(seedCtx, out _).ShouldBeTrue();
+        }
+
+        // Query with two repeated `name:contains` constraints. No organization
+        // satisfies both, so the searchset bundle should have total = 0.
+        FhirRequestContext searchCtx = new()
+        {
+            TenantName = store.Config.ControllerName,
+            Store = store,
+            HttpMethod = "GET",
+            Url = store.Config.BaseUrl + "/Organization",
+            UrlQuery = "name:contains=Foo&name:contains=ZZZNoMatchExpected",
+            Forwarded = null,
+            Authorization = null,
+            SourceFormat = "application/fhir+json",
+            DestinationFormat = "application/fhir+json",
+            ResourceType = "Organization",
+        };
+
+        store.TypeSearch(searchCtx, out FhirResponseContext searchResponse).ShouldBeTrue();
+        searchResponse.SerializedResource.ShouldNotBeNullOrEmpty();
+
+        MinimalBundle? bundle = JsonSerializer.Deserialize<MinimalBundle>(searchResponse.SerializedResource);
+        bundle.ShouldNotBeNull();
+        bundle.BundleType.ShouldBe("searchset");
+        bundle.Total.ShouldBe(
+            0,
+            "repeated `name:contains` parameters must be combined with AND (FHIR R4 §3.1.1.5.7); no Organization contains both 'Foo' and 'ZZZNoMatchExpected'");
+    }
 }


### PR DESCRIPTION
Closes #53.

`ParsedSearchParameter.Parse` previously read each query key's value as `query[key]`, which on `NameValueCollection` is the comma-joined concatenation of all occurrences. That conflated FHIR R4 §3.1.1.5.7's two combining semantics:

| Form | Spec semantics |
|---|---|
| `?name:contains=Foo,Bar` (single occurrence, comma-separated) | OR |
| `?name:contains=Foo&name:contains=Bar` (repeated occurrence) | AND |

This patch iterates `query.GetValues(key)` and emits one `ParsedSearchParameter` per occurrence. Downstream evaluation already AND-combines multiple parameter instances of the same name (verified — the existing test suite continues to pass without changes), so this is the right seam to disentangle the two semantics.

## Verification

- The failing regression test from this branch (`RepeatedSearchParameterShouldUseAndSemantics`) now passes on net8.0/net9.0/net10.0.
- The full candle test suite passes on net8.0/net9.0/net10.0 (693/693 — including the existing search-with-comma-OR tests, confirming OR semantics aren't broken).